### PR TITLE
Add GenerateProgramFile to PropertyGroup

### DIFF
--- a/Test/PageRequestTest.cs
+++ b/Test/PageRequestTest.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using sorteio.models;
+
+namespace sorteio.models.tests
+{
+    [TestFixture]
+    public class PageRequestTest
+    {
+        [TestCase(1, 10)]
+        public void Of_ShouldReturnPageNumber_ReturnsAnInteger(int number, int limit)
+        {
+            var pageRequest = PageRequest.First();
+            var result = PageRequest.Of(number, limit);
+            Assert.True(result.Limit == limit);
+            // Assert.That(result, Is.InstanceOf(pageRequest));
+        }
+    }
+}

--- a/pagination.csproj
+++ b/pagination.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App"/>
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.4"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.1"/>
+    <PackageReference Include="NUnit" Version="3.12.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0"/>
   </ItemGroup>
-
 </Project>

--- a/pagination.csproj
+++ b/pagination.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="NUnit" Version="3.12.0"/>
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0"/>
+    <PackageReference Include="coverlet.collector" Version="1.0.1"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adding <GenerateProgramFile>false</GenerateProgramFile> resolves the multiple entry points problem